### PR TITLE
文字のサイズを少し小さく & アイコンの余白を広げる

### DIFF
--- a/src/app/(index)/users/[userId]/_components/Profile/Profile.tsx
+++ b/src/app/(index)/users/[userId]/_components/Profile/Profile.tsx
@@ -16,7 +16,7 @@ type FieldProps = {
 
 const Field = ({ icon, text }: FieldProps) => (
   <Box sx={{ display: 'flex' }}>
-    <Box>{icon}</Box>
+    <Box sx={{ mr: 1 }}>{icon}</Box>
     <Typography variant='body1'>{text}</Typography>
   </Box>
 )
@@ -61,9 +61,13 @@ export const Profile = ({
           },
           m: 'auto',
           p: '1rem',
+          fontSize: '.95rem',
         }}
       >
-        <Typography sx={{ fontWeight: 'bold' }} variant='h4'>
+        <Typography
+          sx={{ fontWeight: 'bold', fontSize: '1.4rem' }}
+          variant='h4'
+        >
           {name}
         </Typography>
         {bio && <Typography variant='body1'>{bio}</Typography>}


### PR DESCRIPTION
## やったこと

タイトルの通り

## 変更した部分のスクリーンショット (必要があれば)

PC
<img width="1243" alt="スクリーンショット 2024-04-04 22 50 52" src="https://github.com/Yumax-panda/full-stack/assets/93650251/93fa3764-25d0-41af-97a1-e0a9b3d42c43">

モバイル iPhone SE
<img width="393" alt="スクリーンショット 2024-04-04 22 48 34" src="https://github.com/Yumax-panda/full-stack/assets/93650251/55517217-fd18-4f0a-b8f2-d11d0ab4d9c7">


## 動作確認環境

- Chrome バージョン: 123.0.6312.105（Official Build） （arm64）
- macOS Sonoma 14.4.1
