### PR TITLE
safariで開いたときに文言が折れる不具合を修正

### DIFF
--- a/src/app/(index)/settings/tags/_components/TagForm/TagForm.tsx
+++ b/src/app/(index)/settings/tags/_components/TagForm/TagForm.tsx
@@ -193,7 +193,8 @@ export const TagForm = ({
               color='error'
               onClick={onClose}
               size='small'
-              sx={{ mr: 1 }}
+              // safariで開いた場合, 文言が折れてしまうためwhiteSpaceを指定
+              sx={{ mr: 1, whiteSpace: 'nowrap' }}
             >
               キャンセル
             </Button>


### PR DESCRIPTION
## やったこと

タイトルの通り

## 変更した部分のスクリーンショット (必要があれば)

### 変更前

<img width="1254" alt="スクリーンショット 2024-04-05 18 01 58" src="https://github.com/Yumax-panda/full-stack/assets/93650251/9ed05c32-b699-4693-a759-1ffbf17db98c">


### 変更後

<img width="1262" alt="スクリーンショット 2024-04-05 18 02 13" src="https://github.com/Yumax-panda/full-stack/assets/93650251/6d4a9f96-1725-43b7-93dd-83a2363106c5">


## 動作確認環境

safari, chrome

## 備考
