### PR TITLE
1回目のコミット

### DIFF
--- a/src/app/(withAuth)/layout.tsx
+++ b/src/app/(withAuth)/layout.tsx
@@ -1,15 +1,8 @@
-import { notFound } from 'next/navigation'
-
-import { getSession } from '@/lib/auth'
-
 export default async function Layout({
   children,
 }: {
   children: React.ReactNode
   params: { userId: string }
 }) {
-  const session = await getSession()
-  if (!session) notFound()
-
   return <div>{children}</div>
 }

--- a/src/app/(withAuth)/works/[workId]/edit/page.tsx
+++ b/src/app/(withAuth)/works/[workId]/edit/page.tsx
@@ -1,9 +1,11 @@
-import { notFound } from 'next/navigation'
+import { notFound, redirect } from 'next/navigation'
+import { getServerSession } from 'next-auth/next'
 
 import { Editor } from './_components/Editor/Editor'
 
 import type { Metadata } from 'next'
 
+import { authOptions } from '@/app/api/auth/[...nextauth]/route'
 import { env } from '@/lib/env.mjs'
 import { getMyWorkByWorkIdWithoutCache } from '@/usecase/work'
 
@@ -20,8 +22,14 @@ export default async function Edit({
 }: {
   params: { workId: string }
 }) {
+  const session = await getServerSession(authOptions)
+  if (!session) {
+    redirect('/')
+  }
   const work = await getMyWorkByWorkIdWithoutCache(workId)
-  if (!work) notFound()
+  if (!work) {
+    notFound()
+  }
 
   return <Editor work={work} />
 }

--- a/src/app/(withAuth)/works/[workId]/edit/page.tsx
+++ b/src/app/(withAuth)/works/[workId]/edit/page.tsx
@@ -1,11 +1,10 @@
 import { notFound, redirect } from 'next/navigation'
-import { getServerSession } from 'next-auth/next'
 
 import { Editor } from './_components/Editor/Editor'
 
 import type { Metadata } from 'next'
 
-import { authOptions } from '@/app/api/auth/[...nextauth]/route'
+import { getSession } from '@/lib/auth'
 import { env } from '@/lib/env.mjs'
 import { getMyWorkByWorkIdWithoutCache } from '@/usecase/work'
 
@@ -22,9 +21,9 @@ export default async function Edit({
 }: {
   params: { workId: string }
 }) {
-  const session = await getServerSession(authOptions)
+  const session = await getSession()
   if (!session) {
-    redirect('/')
+    notFound()
   }
   const work = await getMyWorkByWorkIdWithoutCache(workId)
   if (!work) {


### PR DESCRIPTION
## やったこと

- (withAuth)/works/[workId]/edit/layout.tsx内でのセッション確認を廃止し、配下のpage.tsx内でgetServerSessionメソッドを利用してセッション確認する実装をした

## 変更した部分のスクリーンショット (必要があれば)

## 動作確認環境

## 備考
- (withAuth)/works/[workId]/editで、ログイン状態ではないときにホームページにリダイレクトする動作は確認したが、(withAuth)/works/[workId]のページでも同様の動作をさせる必要があるのか要確認と考えた
