### PR TITLE
encodeすることでquerySelectorのエラーを回避

### DIFF
--- a/src/app/(index)/works/[workId]/_components/TableOfContents/TableOfContents.tsx
+++ b/src/app/(index)/works/[workId]/_components/TableOfContents/TableOfContents.tsx
@@ -1,4 +1,5 @@
 import { Link } from '@/app/_components/Link'
+import { encodeURLSafe } from '@/lib/utils'
 import { Typography } from '@mui/material'
 import { forwardRef } from 'react'
 import { CardContainer } from '../CardContainer'
@@ -21,7 +22,7 @@ export const TableOfContents = forwardRef<HTMLUListElement | null, Props>(
           {headings.map(({ level, text }, i) => (
             <Link
               key={`heading-${i}-${text}`}
-              href={`#${text}`}
+              href={`#${encodeURLSafe(text)}`}
               className={styles.link}
             >
               <li
@@ -30,7 +31,7 @@ export const TableOfContents = forwardRef<HTMLUListElement | null, Props>(
                 className={
                   styles[`heading${Math.max(1, level - minLevel + 1)}`]
                 }
-                id={getTocId(text)}
+                id={getTocId(encodeURLSafe(text))}
               >
                 {text}
               </li>

--- a/src/app/(index)/works/[workId]/_components/hooks/useContent.ts
+++ b/src/app/(index)/works/[workId]/_components/hooks/useContent.ts
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 
+import { encodeURLSafe } from '@/lib/utils'
 import { type RefObject, useEffect, useRef } from 'react'
 import { ACTIVE_CLASS } from '../utils/constants'
 import { getTocId } from '../utils/id'
@@ -56,8 +57,8 @@ export const useContent = ({ headingTexts }: Props): UseContentReturn => {
 
           // 目次のリンク内で該当する見出しを変更
           for (const text of headingTexts) {
-            const tocId = getTocId(text)
-            const elem = tocRef.current.querySelector(`#${tocId}`)
+            const tocId = getTocId(encodeURLSafe(text))
+            const elem = tocRef.current.querySelector(`[id="${tocId}"]`)
 
             if (elem) {
               if (activeTocId === tocId) {
@@ -75,7 +76,10 @@ export const useContent = ({ headingTexts }: Props): UseContentReturn => {
     )
 
     for (const text of headingTexts) {
-      const headingElem = editorRef.current.querySelector(`#${text}`)
+      const encodedText = encodeURLSafe(text)
+      const headingElem = editorRef.current.querySelector(
+        `[id="${encodedText}"]`,
+      )
 
       if (headingElem) {
         observer.observe(headingElem)

--- a/src/lib/editor/editor.ts
+++ b/src/lib/editor/editor.ts
@@ -4,6 +4,7 @@ import Link from '@tiptap/extension-link' // eslint-disable-line import/no-named
 import Placeholder from '@tiptap/extension-placeholder' // eslint-disable-line import/no-named-as-default
 import { generateJSON as originalGenerateJSON } from '@tiptap/html'
 import StarterKit from '@tiptap/starter-kit' // eslint-disable-line import/no-named-as-default
+import { encodeURLSafe } from '../utils'
 
 import Embed from './ext/embed'
 
@@ -17,8 +18,8 @@ export const extensions = [
         ...this.parent?.(),
         id: {
           default: null,
-          parseHTML: (element) => ({
-            id: element.textContent,
+          parseHTML: ({ textContent }) => ({
+            id: textContent ? encodeURLSafe(textContent) : null,
           }),
           renderHTML: (attributes) => attributes.id,
         },

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+export const replaceWhitespace = (text: string): string => {
+  return text.replace(/\s/g, '-')
+}
+
+export const encodeURLSafe = (text: string): string =>
+  encodeURIComponent(replaceWhitespace(text).toLowerCase())


### PR DESCRIPTION
## やったこと

- 例: トップページの誤字を修正した

## 変更した部分のスクリーンショット (必要があれば)

## 動作確認環境

## 備考
